### PR TITLE
MQTT TLS support

### DIFF
--- a/mqtt.conf
+++ b/mqtt.conf
@@ -16,6 +16,14 @@ mqtt_clientid = 'broadlink'
 mqtt_username = ''
 mqtt_password = ''
 mqtt_topic_prefix = 'broadlink/'
+## MQTT TLS parameters
+# Required with TLS: a string path to the Certificate Authority certificate files that are to be treated as trusted by this client.
+# ca_certs = '/path/to/ca_certsfile'
+# Optional Clients Cert/Key
+# certfile = '/path/to/certfile'
+# keyfile  = '/path/to/keyfile'
+# Required TLS version. Valid values: 'sslv3', 'tlsv1', 'tlsv1.2'
+# tls_version = 'tlsv1.2'
 
 ## extra parameters
 #broadlink_rm_temperature_interval = 120 # publish temperature from RM device to broadlink/temperature topic every two minutes

--- a/mqtt.py
+++ b/mqtt.py
@@ -9,6 +9,11 @@ import logging
 import logging.config
 import socket
 import sched
+HAVE_TLS = True
+try:
+    import ssl
+except ImportError:
+    HAVE_TLS = False
 from threading import Thread
 from test import TestDevice
 
@@ -21,7 +26,33 @@ CONFIG = os.getenv('BROADLINKMQTTCONFIG', dirname + 'mqtt.conf')
 class Config(object):
     def __init__(self, filename=CONFIG):
         self.config = {}
+        self.config['ca_certs']     = None
+        self.config['tls_version']  = None
+        self.config['certfile']     = None
+        self.config['keyfile']      = None
+        self.config['tls_insecure'] = False
+        self.config['tls']          = False
         execfile(filename, self.config)
+
+        if HAVE_TLS == False:
+            logging.error("TLS parameters set but no TLS available (SSL)")
+            sys.exit(2)
+
+        if self.config.get('ca_certs') is not None:
+            self.config['tls'] = True
+
+        if self.config.get('tls_version') is not None:
+            if self.config.get('tls_version') == 'tlsv1':
+                self.config['tls_version'] = ssl.PROTOCOL_TLSv1
+            if self.config.get('tls_version') == 'tlsv1.2':
+                # TLS v1.2 is available starting from python 2.7.9 and requires openssl version 1.0.1+.
+                if sys.version_info >= (2,7,9):
+                    self.config['tls_version'] = ssl.PROTOCOL_TLSv1_2
+                else:
+                    # fallback to TLSv1 if TLSv1.2 is now available
+                    self.config['tls_version'] = ssl.PROTOCOL_TLSv1
+            if self.config.get('tls_version') == 'sslv3':
+                self.config['tls_version'] = ssl.PROTOCOL_SSLv3
 
     def get(self, key, default='special empty value'):
         v = self.config.get(key, default)
@@ -244,6 +275,12 @@ if __name__ == '__main__':
 
     # Delays will be: 3, 6, 12, 24, 30, 30, ...
     # mqttc.reconnect_delay_set(delay=3, delay_max=30, exponential_backoff=True)
+
+    if cf.get('tls') == True:
+        mqttc.tls_set(cf.get('ca_certs'), cf.get('certfile'), cf.get('keyfile'), tls_version=cf.get('tls_version'), ciphers=None)
+
+    if cf.get('tls_insecure'):
+        mqttc.tls_insecure_set(True)
 
     mqttc.username_pw_set(cf.get('mqtt_username'), cf.get('mqtt_password'))
     mqttc.connect(cf.get('mqtt_broker', 'localhost'), int(cf.get('mqtt_port', '1883')), 60)

--- a/mqtt.py
+++ b/mqtt.py
@@ -49,8 +49,8 @@ class Config(object):
                 if sys.version_info >= (2,7,9):
                     self.config['tls_version'] = ssl.PROTOCOL_TLSv1_2
                 else:
-                    # fallback to TLSv1 if TLSv1.2 is now available
-                    self.config['tls_version'] = ssl.PROTOCOL_TLSv1
+                    logging.error("TLS version 1.2 not available but 'tlsv1.2' is set.")
+            	    sys.exit(2)
             if self.config.get('tls_version') == 'sslv3':
                 self.config['tls_version'] = ssl.PROTOCOL_SSLv3
 


### PR DESCRIPTION
This PR adds TLS support when connecting to the mqtt broker.
Minimal documentation provided in mqtt.conf
'tls_insecure' setting intentionally left out of the sample config.

original TLS code/settings in [mqttwarn](https://github.com/jpmens/mqttwarn) reworked/adapted to be used here.