### PR TITLE
Add pathlib for cross platform file systems and other minor fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+custom.conf
+*.log
+__pycache__/
+commands/*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
    * [**Dooya DT360E**](#dooya-dt360e) curtain motor (device_type = 'dooya')  
    * [**BG1**](#bg1) BG smart socket (device_type = 'bg1')  
 
- 
+
 ## Installation
 Clone *broadlink-mqtt* repository using  
 `git clone https://github.com/eschava/broadlink-mqtt.git`  
@@ -88,19 +88,28 @@ To restart the service:
 # RM2/RM3/RM4
 ### MQTT commands to control IR/RF
 #### Recording (IR or RF)
-To record new command just send `record` message for IR command or `recordrf` for RF command to the topic `broadlink/COMMAND_ID`,  
+To record new command just send `record` payload message for IR command or `recordrf` for RF command to the topic `broadlink/COMMAND_ID`,  
 where COMMAND_ID is any identifier that can be used for file name (slashes are also allowed)  
+
 > **NOTE**: It seems that Python3 is a must for recording RF signals  
 
-**Example**: to record power button for Samsung TV send  
-`record` -> `broadlink/tv/samsung/power`  
+**Example**: to record power button for Samsung TV write **`record`** to payload of topic `broadlink/tv/samsung/power`
+
+```
+record -> broadlink/tv/samsung/power
+```
+
 and recorded interpretation of IR signal will be saved to file `commands/tv/samsung/power`
 
 #### Replay
-To replay previously recorded command send `replay` message to the topic `broadlink/COMMAND_ID`,  
+To replay previously recorded command send `replay` payload message to the topic `broadlink/COMMAND_ID`,  
 where COMMAND_ID is identifier if the command  
-**Example**: to replay power button for Samsung TV send  
-`replay` -> `broadlink/tv/samsung/power`  
+**Example**: to replay power button for Samsung TV write **`replay`** to payload of topic `broadlink/tv/samsung/power`
+
+```
+replay -> broadlink/tv/samsung/power
+```
+
 and saved interpretation of IR signal will be replayed from file `commands/tv/samsung/power`
 
 Another format for replaying recorded command is using file name as a message and folder as MQTT topic.  
@@ -126,7 +135,7 @@ Macros scenario file could contain:
  - IR commands (same as `COMMAND_ID` in replay mode)
  - pause instructions (`pause DELAY_IN_MILLISECONDS`)
  - comments (lines started with `#`)
- 
+
 ### Subscription to current temperature (RM2/RM4 devices)
 Need to set `broadlink_rm_temperature_interval` configuration parameter to a number of seconds between periodic updates.  
 E.g. 

--- a/custom.conf
+++ b/custom.conf
@@ -1,3 +1,0 @@
-# This file added to put here configuration parameters overriding default config from mqtt.conf
-# It was added to to avoid GIT conflicts while updating to new revision
-

--- a/mqtt.py
+++ b/mqtt.py
@@ -14,6 +14,8 @@ import binascii
 import types
 from threading import Thread
 from test import TestDevice
+from pathlib import Path
+from os.path import abspath
 
 HAVE_TLS = True
 try:
@@ -22,11 +24,12 @@ except ImportError:
     HAVE_TLS = False
 
 # read initial config files
-dirname = os.path.dirname(os.path.abspath(__file__)) + '/'
-logging.config.fileConfig(dirname + 'logging.conf')
-CONFIG = os.getenv('BROADLINKMQTTCONFIG', dirname + 'mqtt.conf')
-CONFIG_CUSTOM = os.getenv('BROADLINKMQTTCONFIGCUSTOM', dirname + 'custom.conf')
+dirname = os.getcwd()
 
+logging.config.fileConfig(Path(dirname) / 'logging.conf/')
+
+CONFIG = os.getenv('BROADLINKMQTTCONFIG', Path(dirname) / 'mqtt.conf/')
+CONFIG_CUSTOM = os.getenv('BROADLINKMQTTCONFIGCUSTOM', Path(dirname) / 'custom.conf')
 
 class Config(object):
     def __init__(self, filename=CONFIG, custom_filename=CONFIG_CUSTOM):
@@ -182,8 +185,9 @@ def on_message(client, device, msg):
 
         # RM2/RM4 record/replay control
         if device.type == 'RM2' or device.type == 'RM4':
-            file = dirname + "commands/" + command
-            handy_file = file + '/' + action
+            file = Path(dirname) / "commands/" / command
+            
+            handy_file = file / action
 
             if action == '' or action == 'auto':
                 record_or_replay(device, file)
@@ -204,7 +208,7 @@ def on_message(client, device, msg):
                 replay(device, file)
                 return
             elif action == 'macro':
-                file = dirname + "macros/" + command
+                file = Path(dirname) / "macros/" + command
                 macro(device, file)
                 return
 
@@ -244,14 +248,18 @@ def record_or_replay_rf(device, file):
 
 
 def record(device, file):
-    logging.debug("Recording command to file " + file)
+    logging.debug("Recording IR command to file " + abspath(file))
+    logging.debug("Starting learning mode. Press a button on your remote controller in 30 seconds.")
     # receive packet
     device.enter_learning()
     ir_packet = None
     attempt = 0
     while ir_packet is None and attempt < 6:
         time.sleep(5)
-        ir_packet = device.check_data()
+        try:
+            ir_packet = device.check_data()
+        except Exception as e: 
+            logging.warning(str(e) + '. Did you hit the IR remote button?')
         attempt = attempt + 1
     if ir_packet is not None:
         # write to file
@@ -260,13 +268,13 @@ def record(device, file):
             os.makedirs(directory)
         with open(file, 'wb') as f:
             f.write(binascii.hexlify(ir_packet))
-        logging.debug("Done")
+        logging.debug("Done. Created file " + abspath(file))
     else:
-        logging.warn("No command received")
+        logging.warning("No command received in 30 seconds. Exiting learning mode.")
 
 
 def record_rf(device, file):
-    logging.debug("Recording RF command to file " + file)
+    logging.debug("Recording RF command to file " + abspath(file))
     logging.debug("Learning RF Frequency, press and hold the button to learn...")
 
     device.sweep_frequency()
@@ -277,7 +285,7 @@ def record_rf(device, file):
         timeout -= 1
 
     if timeout <= 0:
-        logging.warn("RF Frequency not found")
+        logging.warning("RF Frequency not found")
         device.cancel_sweep_frequency()
         return
 
@@ -291,7 +299,10 @@ def record_rf(device, file):
     attempt = 0
     while rf_packet is None and attempt < 6:
         time.sleep(5)
-        rf_packet = device.check_data()
+        try:
+            rf_packet = device.check_data()
+        except Exception as e: 
+            logging.warning(str(e) + '. Did you hit the RF remote button?')
         attempt = attempt + 1
     if rf_packet is not None:
         # write to file
@@ -300,20 +311,20 @@ def record_rf(device, file):
             os.makedirs(directory)
         with open(file, 'wb') as f:
             f.write(binascii.hexlify(rf_packet))
-        logging.debug("Done")
+        logging.debug("Done. Created file " + abspath(file))
     else:
-        logging.warn("No command received")
+        logging.warning("No command received in 30 seconds. Exiting learning mode.")
 
 
 def replay(device, file):
-    logging.debug("Replaying command from file " + file)
+    logging.debug("Replaying command from file " + abspath(file))
     with open(file, 'rb') as f:
         ir_packet = f.read()
     device.send_data(binascii.unhexlify(ir_packet.strip()))
 
 
 def macro(device, file):
-    logging.debug("Replaying macro from file " + file)
+    logging.debug("Replaying macro from file " + abspath(file))
     with open(file, 'r') as f:
         for line in f:
             line = line.strip(' \n\r\t')
@@ -324,7 +335,7 @@ def macro(device, file):
                 logging.debug("Pause for " + str(pause) + " milliseconds")
                 time.sleep(pause / 1000.0)
             else:
-                command_file = dirname + "commands/" + line
+                command_file = Path(dirname) / "commands/" + line
                 replay(device, command_file)
 
 
@@ -607,7 +618,7 @@ if __name__ == '__main__':
             mqttc.connect(cf.get('mqtt_broker', 'localhost'), int(cf.get('mqtt_port', '1883')), 60)
             mqttc.loop_forever()
         except socket.error:
-            logging.warn("Cannot connect to MQTT server, will try to reconnect in 5 seconds")
+            logging.warning("Cannot connect to MQTT server, will try to reconnect in 5 seconds")
             time.sleep(5)
         except KeyboardInterrupt:
             sys.exit(0)


### PR DESCRIPTION
I used it on Windows system. 
Fixed cross platform (slash, backslash), tipically for system environment using latest pathlib for Python 3+.
It is required a test on Linux system. 