### PR TITLE
Adding Suport to send topic messages for all devices on network

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Format supports next placeholders:
    * `{mac}` - MAC address of the device  
    * `{mac_nic}` - last 3 octets of the MAC address (NIC)  
 
+If you want send commands for all devices on network, you can send the "broadcast MAC" on topic, for example:
+`broadlink/ff_ff_ff_ff_ff_ff/`
+This prossibility just work if `mqtt_multiple_subprefix_format'` was `{mac}/'`
+
 ## Connect Broadlink device to wifi
 You need to use the [Broadlink e-control app](https://play.google.com/store/apps/details?id=com.broadlink.rmt) or [Broadlink Intelligent Home Center](https://play.google.com/store/apps/details?id=cn.com.broadlink.econtrol.plus) to get the device connected to wifi. **Don't use** [BroadLink -Universal TV Remote](https://play.google.com/store/apps/details?id=cn.com.broadlink.econtrol.international), as it is known to lock devices. Other apps have not been tested.
 


### PR DESCRIPTION
When using the option multiple-lookup on the configuration file mqtt.conf, we have the hability to specify which broadlink to submit the message. But, if we want the old behaviour, we need to modify the configuration file everytime.

To avoid that, implement a broadcast address, which allows sending a command to all broadlinks on the network.

This allow a project to have `device_type = multiple-lookup` option, and send a command to a specific device, or just send to the broadcast address in case it doesn't know the address of the device (if there is only one device present) or if doesn't care to send the command to all devices on the network.

For the user to not need to write MAC Address or edit mqtt.conf if they have just one broadlink,They can send the MAC Broadcast on topic and all devices on network (sometimes the user has just one), will be activated.

If The user has more broadlinks, they just write broadlink MAC Address on topic. So they doesn't need to change mqtt.conf all times.

broadlink broadcast is "FF:FF:FF:FF:FF:FF" and in the topic it is "ff_ff_ff_ff_ff_ff".