### PR TITLE
fixing an issue with the breaking changes from the paho library >= 2

### DIFF
--- a/mqtt.py
+++ b/mqtt.py
@@ -597,7 +597,7 @@ if __name__ == '__main__':
 
     clientid = cf.get('mqtt_clientid', 'broadlink-%s' % os.getpid())
     # initialise MQTT broker connection
-    mqttc = paho.Client(clientid, clean_session=cf.get('mqtt_clean_session', False), userdata=devices)
+    mqttc = paho.Client(paho.CallbackAPIVersion.VERSION1, clientid, clean_session=cf.get('mqtt_clean_session', False), userdata=devices)
 
     mqttc.on_message = on_message
     mqttc.on_connect = on_connect


### PR DESCRIPTION
With Release 2.0 of the paho library there were [breaking changes](https://eclipse.dev/paho/files/paho.mqtt.python/html/migrations.html) introduced - this PR adresses them and makes the client work with paho releases >=2

```
[2024-05-19 05:18:08,457] DEBUG Connected to 'RMMINIB' Broadlink device at '192.168.106.13' (MAC <redacted>) and started listening to MQTT commands at 'broadlink/#'
Traceback (most recent call last):
  File "/software/broadlink-mqtt/mqtt.py", line 600, in <module>
    mqttc = paho.Client(clientid, clean_session=cf.get('mqtt_clean_session', False), userdata=devices)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/paho/mqtt/client.py", line 772, in __init__
    raise ValueError(
ValueError: Unsupported callback API version: version 2.0 added a callback_api_version, see docs/migrations.rst for details
root@bitsas16:/software/broadlink-mqtt# python3 mqtt.py
[2024-05-19 05:20:04,508] DEBUG Connected to 'RMMINIB' Broadlink device at '192.168.106.13' (MAC e8:70:72:04:ee:11) and started listening to MQTT commands at 'broadlink/#'
Traceback (most recent call last):
  File "/software/broadlink-mqtt/mqtt.py", line 600, in <module>
    mqttc = paho.Client(clientid, clean_session=cf.get('mqtt_clean_session', False), userdata=devices)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/paho/mqtt/client.py", line 772, in __init__
    raise ValueError(
ValueError: Unsupported callback API version: version 2.0 added a callback_api_version, see docs/migrations.rst for details
```